### PR TITLE
add provisioned concurrency

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
             sam package --template-file template.yml --output-template-file "$OUTPUT_TEMPLATE_FILE" --s3-bucket "$BUCKET_NAME"
             sam deploy \
               --capabilities CAPABILITY_IAM \
-              --parameter-overrides GitHubClientIdParameter="$GITHUB_CLIENT_ID" GitHubClientSecretParameter="$GITHUB_CLIENT_SECRET" CognitoRedirectUriParameter="$COGNITO_REDIRECT_URI" StageNameParameter="$STAGE" \
+              --parameter-overrides CognitoRedirectUriParameter="$COGNITO_REDIRECT_URI" GitHubClientIdParameter="$GITHUB_CLIENT_ID" GitHubClientSecretParameter="$GITHUB_CLIENT_SECRET" LambdaProvisionedConcurrentExecutions=$LAMBDA_PROVISIONIONED_CONCURRENT_EXECUTIONS StageNameParameter="$STAGE" \
               --region "$REGION" \
               --role-arn "$STACK_ROLE_ARN" \
               --stack-name "$STACK_NAME" \
@@ -43,6 +43,7 @@ jobs:
           COGNITO_REDIRECT_URI: ${{ secrets.COGNITO_REDIRECT_URI }}
           GITHUB_CLIENT_ID: ${{ secrets.GITHUB_CLIENT_ID }}
           GITHUB_CLIENT_SECRET: ${{ secrets.GITHUB_CLIENT_SECRET }}
+          LAMBDA_PROVISIONIONED_CONCURRENT_EXECUTIONS: 1
           OUTPUT_TEMPLATE_FILE: serverless-output.yml
           NODE_ENV: production
           REGION: us-east-1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
             sam package --template-file template.yml --output-template-file "$OUTPUT_TEMPLATE_FILE" --s3-bucket "$BUCKET_NAME"
             sam deploy \
               --capabilities CAPABILITY_IAM \
-              --parameter-overrides CognitoRedirectUriParameter="$COGNITO_REDIRECT_URI" GitHubClientIdParameter="$GITHUB_CLIENT_ID" GitHubClientSecretParameter="$GITHUB_CLIENT_SECRET" LambdaProvisionedConcurrentExecutions=$LAMBDA_PROVISIONIONED_CONCURRENT_EXECUTIONS StageNameParameter="$STAGE" \
+              --parameter-overrides CognitoRedirectUriParameter="$COGNITO_REDIRECT_URI" GitHubClientIdParameter="$GITHUB_CLIENT_ID" GitHubClientSecretParameter="$GITHUB_CLIENT_SECRET" LambdaProvisionedConcurrentExecutions=$LAMBDA_PROVISIONED_CONCURRENT_EXECUTIONS StageNameParameter="$STAGE" \
               --region "$REGION" \
               --role-arn "$STACK_ROLE_ARN" \
               --stack-name "$STACK_NAME" \
@@ -43,7 +43,7 @@ jobs:
           COGNITO_REDIRECT_URI: ${{ secrets.COGNITO_REDIRECT_URI }}
           GITHUB_CLIENT_ID: ${{ secrets.GITHUB_CLIENT_ID }}
           GITHUB_CLIENT_SECRET: ${{ secrets.GITHUB_CLIENT_SECRET }}
-          LAMBDA_PROVISIONIONED_CONCURRENT_EXECUTIONS: 1
+          LAMBDA_PROVISIONED_CONCURRENT_EXECUTIONS: 1
           OUTPUT_TEMPLATE_FILE: serverless-output.yml
           NODE_ENV: production
           REGION: us-east-1

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -22,7 +22,7 @@ aws s3 mb "s3://$BUCKET_NAME" --region "$REGION" || true
 sam package --template-file template.yml --output-template-file "$OUTPUT_TEMPLATE_FILE"  --s3-bucket "$BUCKET_NAME"
 sam deploy \
   --capabilities CAPABILITY_IAM \
-  --parameter-overrides CognitoRedirectUriParameter="$COGNITO_REDIRECT_URI" GitHubClientIdParameter="$GITHUB_CLIENT_ID" GitHubClientSecretParameter="$GITHUB_CLIENT_SECRET" LambdaProvisionedConcurrentExecutions=$LAMBDA_PROVISIONIONED_CONCURRENT_EXECUTIONS StageNameParameter="$STAGE_NAME" \
+  --parameter-overrides CognitoRedirectUriParameter="$COGNITO_REDIRECT_URI" GitHubClientIdParameter="$GITHUB_CLIENT_ID" GitHubClientSecretParameter="$GITHUB_CLIENT_SECRET" LambdaProvisionedConcurrentExecutions=$LAMBDA_PROVISIONED_CONCURRENT_EXECUTIONS StageNameParameter="$STAGE_NAME" \
   --region "$REGION" \
   --stack-name "$STACK_NAME" \
   --template-file "$OUTPUT_TEMPLATE_FILE"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -22,7 +22,7 @@ aws s3 mb "s3://$BUCKET_NAME" --region "$REGION" || true
 sam package --template-file template.yml --output-template-file "$OUTPUT_TEMPLATE_FILE"  --s3-bucket "$BUCKET_NAME"
 sam deploy \
   --capabilities CAPABILITY_IAM \
-  --parameter-overrides GitHubClientIdParameter="$GITHUB_CLIENT_ID" GitHubClientSecretParameter="$GITHUB_CLIENT_SECRET" CognitoRedirectUriParameter="$COGNITO_REDIRECT_URI" StageNameParameter="$STAGE_NAME" \
+  --parameter-overrides GitHubClientIdParameter="$GITHUB_CLIENT_ID" GitHubClientSecretParameter="$GITHUB_CLIENT_SECRET" LambdaProvisionedConcurrentExecutions=$LAMBDA_PROVISIONIONED_CONCURRENT_EXECUTIONS CognitoRedirectUriParameter="$COGNITO_REDIRECT_URI" StageNameParameter="$STAGE_NAME" \
   --region "$REGION" \
   --stack-name "$STACK_NAME" \
   --template-file "$OUTPUT_TEMPLATE_FILE"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -22,7 +22,7 @@ aws s3 mb "s3://$BUCKET_NAME" --region "$REGION" || true
 sam package --template-file template.yml --output-template-file "$OUTPUT_TEMPLATE_FILE"  --s3-bucket "$BUCKET_NAME"
 sam deploy \
   --capabilities CAPABILITY_IAM \
-  --parameter-overrides GitHubClientIdParameter="$GITHUB_CLIENT_ID" GitHubClientSecretParameter="$GITHUB_CLIENT_SECRET" LambdaProvisionedConcurrentExecutions=$LAMBDA_PROVISIONIONED_CONCURRENT_EXECUTIONS CognitoRedirectUriParameter="$COGNITO_REDIRECT_URI" StageNameParameter="$STAGE_NAME" \
+  --parameter-overrides CognitoRedirectUriParameter="$COGNITO_REDIRECT_URI" GitHubClientIdParameter="$GITHUB_CLIENT_ID" GitHubClientSecretParameter="$GITHUB_CLIENT_SECRET" LambdaProvisionedConcurrentExecutions=$LAMBDA_PROVISIONIONED_CONCURRENT_EXECUTIONS StageNameParameter="$STAGE_NAME" \
   --region "$REGION" \
   --stack-name "$STACK_NAME" \
   --template-file "$OUTPUT_TEMPLATE_FILE"

--- a/template.yml
+++ b/template.yml
@@ -10,32 +10,34 @@ Globals:
     Timeout: 15
     Environment:
       Variables:
-        GITHUB_CLIENT_ID:
-          Ref: GitHubClientIdParameter
-        GITHUB_CLIENT_SECRET:
-          Ref: GitHubClientSecretParameter
         COGNITO_REDIRECT_URI:
           Ref: CognitoRedirectUriParameter
         GITHUB_API_URL:
           Ref: GitHubUrlParameter
+        GITHUB_CLIENT_ID:
+          Ref: GitHubClientIdParameter
+        GITHUB_CLIENT_SECRET:
+          Ref: GitHubClientSecretParameter
         GITHUB_LOGIN_URL:
           Ref: GitHubLoginUrlParameter
 
 Parameters:
+  CognitoRedirectUriParameter:
+    Type: String
   GitHubClientIdParameter:
     Type: String
   GitHubClientSecretParameter:
     Type: String
-  CognitoRedirectUriParameter:
-    Type: String
-  GitHubUrlParameter:
-    Type: String
-    Default: "https://api.github.com"
-    MinLength: 1
   GitHubLoginUrlParameter:
     Type: String
     Default: "https://github.com"
     MinLength: 1
+  GitHubUrlParameter:
+    Type: String
+    Default: "https://api.github.com"
+    MinLength: 1
+  LambdaProvisionedConcurrentExecutions:
+    Type: Number
   StageNameParameter:
     Type: String
 
@@ -72,6 +74,11 @@ Resources:
             Path: /.well-known/openid-configuration
             Method: get
             RestApiId: !Ref GithubOAuthApi
+      AutoPublishAlias: live
+      DeploymentPreference:
+        Type: AllAtOnce
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: !Ref LambdaProvisionedConcurrentExecutions
 
   Authorize:
     Type: AWS::Serverless::Function
@@ -93,6 +100,11 @@ Resources:
           DYNAMODB_STATE_TABLE:
             Ref: CognitoStatesTable
           REGION: !Ref "AWS::Region"
+      AutoPublishAlias: live
+      DeploymentPreference:
+        Type: AllAtOnce
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: !Ref LambdaProvisionedConcurrentExecutions
 
   Token:
     Type: AWS::Serverless::Function
@@ -112,6 +124,11 @@ Resources:
             Path: /token
             Method: post
             RestApiId: !Ref GithubOAuthApi
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: !Ref LambdaProvisionedConcurrentExecutions
+      DeploymentPreference:
+        Type: AllAtOnce
 
   UserInfo:
     Type: AWS::Serverless::Function
@@ -131,6 +148,11 @@ Resources:
             Path: /userinfo
             Method: post
             RestApiId: !Ref GithubOAuthApi
+      AutoPublishAlias: live
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: !Ref LambdaProvisionedConcurrentExecutions
+      DeploymentPreference:
+        Type: AllAtOnce
 
   Jwks:
     Type: AWS::Serverless::Function
@@ -144,6 +166,11 @@ Resources:
             Path: /.well-known/jwks.json
             Method: get
             RestApiId: !Ref GithubOAuthApi
+      AutoPublishAlias: live
+      DeploymentPreference:
+        Type: AllAtOnce
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: !Ref LambdaProvisionedConcurrentExecutions
 
   Callback:
     Type: AWS::Serverless::Function
@@ -165,6 +192,11 @@ Resources:
           DYNAMODB_STATE_TABLE:
             Ref: CognitoStatesTable
           REGION: !Ref "AWS::Region"
+      AutoPublishAlias: live
+      DeploymentPreference:
+        Type: AllAtOnce
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: !Ref LambdaProvisionedConcurrentExecutions
 
 Outputs:
   GitHubShimIssuer:


### PR DESCRIPTION
this adds support for provisioned concurrency to avoid (potential) warm up costs when signing in with github sso. the setting is currently hard-coded in the production deployment to `1`.