### PR TITLE
force upload with new logs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           args: |
             ls -al .
-            sam package --debug --template-file template.yml --output-template-file "$OUTPUT_TEMPLATE_FILE" --s3-bucket "$BUCKET_NAME"
+            sam package --debug --force-upload --template-file template.yml --output-template-file "$OUTPUT_TEMPLATE_FILE" --s3-bucket "$BUCKET_NAME"
             echo "packaged successfully!"
             sam deploy \
               --capabilities CAPABILITY_IAM \


### PR DESCRIPTION
making progress on the build issue. uncovered this log and the timeout that happens after a few attempts. try to `force-upload` now.

```
File with same data is already exists at f3a0e684dd7fe62885db722a19e46d32. Skipping upload
```

## Related issues

> Fix [#1]()

## Checklists
- [ ] Make sure to link ticket
- [ ] Make sure announce/discuss any changes to the #compliance channel in slack
