### PR TITLE
use vanta tags for ownership

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,8 +4,9 @@
 
 ## Related issues
 
-> Fix [#1]()
+Resolves [#1]()
 
 ## Checklists
 - [ ] Make sure to link ticket
 - [ ] Make sure announce/discuss any changes to the #compliance channel in slack
+- [ ] Vanta tags have been added for #compliance purproses

--- a/aws-cloudformations/dynamo-example.yml
+++ b/aws-cloudformations/dynamo-example.yml
@@ -1,5 +1,5 @@
 Resources:
-  CognitoStatesTable:
+  ExampleTable:
     Type: AWS::DynamoDB::Table
     Properties:
       AttributeDefinitions:
@@ -9,15 +9,15 @@ Resources:
         - AttributeName: id
           KeyType: HASH
       BillingMode: PAY_PER_REQUEST
-      TimeToLiveSpecification:
-        AttributeName: ttl
-        Enabled: true
+      # TimeToLiveSpecification:
+      #   AttributeName: ttl
+      #   Enabled: true
     Tags:
       - Key: VantaOwner
         Value: ${self:custom.vanta.owner}
       - Key: VantaNonProd
         Value: ${self:custom.vanta.nonProd}
       - Key: VantaDescription
-        Value: "Temporary storage for github user sign up and sign in oauth states"
+        Value: "Description of the Bucket"
       - Key: VantaContainsUserData
-        Value: false
+        Value: false # true if contains user data

--- a/aws-cloudformations/dynamo-example.yml
+++ b/aws-cloudformations/dynamo-example.yml
@@ -18,6 +18,6 @@ Resources:
       - Key: VantaNonProd
         Value: ${self:custom.vanta.nonProd}
       - Key: VantaDescription
-        Value: "Description of the Bucket"
+        Value: "Description of the Table"
       - Key: VantaContainsUserData
         Value: false # true if contains user data

--- a/aws-cloudformations/dynamo.yml
+++ b/aws-cloudformations/dynamo.yml
@@ -18,6 +18,6 @@ Resources:
       - Key: VantaNonProd
         Value: ${self:custom.vanta.nonProd}
       - Key: VantaDescription
-        Value: "Temporary storage for github user sign up and sign in oauth states"
+        Value: "Temporary storage for github user sign up and sign in states"
       - Key: VantaContainsUserData
         Value: false

--- a/serverless.yml
+++ b/serverless.yml
@@ -51,6 +51,12 @@ custom:
   stage: ${opt:stage, self:provider.stage}
   webpack:
     webpackConfig: 'webpack.config.serverless.js'
+  vanta:
+    disabled:
+      default: true
+      production: false
+    owner: "troy@trycourier.com"
+    nonProd: ${self:custom.vanta.disabled.${self:custom.stage}, self:custom.vanta.disabled.default}
 
 functions:
   authorize:


### PR DESCRIPTION
Currently, each time a resource is added to our stack, we must manually detail information in Vanta for inventory purposes. Vanta supports automating this process via tagging. This pull request:

* Adds a tag to the dynamo `oauth states` table
* Provides a `dynamo-example.yml` for any future dynamo tables
* Updates the pull request template to request tags be added

Resolves https://linear.app/issue/C-686/add-vanta-tags-to-open-id-wrapper