### PR TITLE
auto verify github-verified emails

### DIFF
--- a/aws-cloudformations/cognito.yml
+++ b/aws-cloudformations/cognito.yml
@@ -4,6 +4,7 @@ Resources:
     Properties:
       AttributeMapping: {
         email: "email",
+        email_verified: "email_verified",
         gender: "gender",
         locale: "locale",
         name: "name",


### PR DESCRIPTION
resolves https://linear.app/trycourier/issue/C-1189/auto-verify-github-email

### two verified github users
* ✅ first was an _existing user_ that did not have an email verified in cognito (verified in github). adding this property auto-verified the email on next sign in to courier ✅
* ✅ second was a _new user_ that already had a verified email in github => successfully verified in cognito

![image](https://user-images.githubusercontent.com/266481/87187851-aeb7e800-c2a2-11ea-802e-e38da03218fd.png)

